### PR TITLE
Bug fixes for m4m commands

### DIFF
--- a/commands/m4m_task_assignee_finder.py
+++ b/commands/m4m_task_assignee_finder.py
@@ -213,7 +213,7 @@ async def recommend_assignees_secondary(past_replies: list[str], task_given: str
         user_prompt = (
             "You are a helpful assistant recommending assignees for a GitHub task. Consider all previous user requests and your past replies. "
             "Only list 5-8 assignees using markdown: "
-            "'1) Assignee Name ((Country Emoji + Country Code only if given) + Phone Number, Email)'."
+            "'1) Assignee Name ((Country Emoji + Country Code only if given) + Phone Number, Email). Reason for choosing: (Explanation)'."
             "No prelude, epilogue, or follow-up questions.\n\n"
             f"Task in need of an assignee:\n\n{task_given}\n"
             f"Conversation so far:\n{conversation_context}\n"

--- a/commands/m4m_task_mentor_agent.py
+++ b/commands/m4m_task_mentor_agent.py
@@ -242,7 +242,6 @@ class MantisCog(commands.Cog):
 
 
             async with interaction.channel.typing():
-                session = self.cog.sessions.get(self.user_id, {})
                 existing_context = session.get("issue_context", "")
                 new_tasks = await recommend_tasks_secondary(existing_context)
                 session["issue_context"] = existing_context + "\n\n" + new_tasks

--- a/commands/m4m_task_mentor_agent.py
+++ b/commands/m4m_task_mentor_agent.py
@@ -377,8 +377,8 @@ class MantisCog(commands.Cog):
                     return
 
                 issue_url = message.content.strip()
-                sent_message = await message.reply("Perfect. Let me try to assign that to you now...", mention_author=False)
-                session["last_bot_message_id"] = sent_message.id
+                # sent_message = await message.reply("Perfect. Let me try to assign that to you now...", mention_author=False)
+                # session["last_bot_message_id"] = sent_message.id
                 
                 async with message.channel.typing():
                     assign_response = assign_task_to_user(github_username, issue_url)


### PR DESCRIPTION
When using m4m_find_assignee and then ManolisGPT, I found that I would get m4m_find_assignee replies when I was replying to a ManolisGPT response. This PR fixes that issue and also makes improvements to the user experience of using the bot.